### PR TITLE
Feat/pw/standardized formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# python gitignore
+*.pyc
+__pycache__/
+.DS_Store

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,0 @@
-[MASTER]
-[MESSAGES CONTROL]
-disable=C0114,C0115,C0116,R0903,E0401, E0611, C0103 # missing-module-docstring, missing-class-docstring, missing-function-docstring, too-few-public-methods, import-error invalid-name

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["charliermarsh.ruff"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnType": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "always",
+      "source.organizeImports.ruff": "always"
+    }
+  },
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "editor.tabSize": 2,
+  "editor.bracketPairColorization.enabled": true
+}

--- a/baseline/.gitignore
+++ b/baseline/.gitignore
@@ -1,4 +1,0 @@
-# python gitignore
-*.pyc
-__pycache__/
-.DS_Store

--- a/baseline/projectivize.py
+++ b/baseline/projectivize.py
@@ -2,10 +2,12 @@
 # Usage: python projectivize.py < CONLL > CONLL
 
 # Bonus: Count the number of projective trees
+from collections.abc import Iterable
+from typing import TextIO
 
 
-def trees(fp):
-    buffer = []
+def trees(fp: TextIO) -> Iterable[list[str]]:
+    buffer: list[str] = []
     for line in fp:
         stripped_line = line.rstrip()  # strip off the trailing newline
         if not stripped_line.startswith("#"):
@@ -18,7 +20,7 @@ def trees(fp):
                     buffer.append(columns)
 
 
-def heads(rows):
+def heads(rows: list[str]) -> list[int]:
     return [0] + [int(row[6]) for row in rows]
 
 
@@ -27,9 +29,9 @@ SH = 0
 UP = -1
 
 
-def traverse(heads):
-    marked = [False] * len(heads)
-    cursor = 0
+def traverse(heads: list[int]) -> Iterable[tuple[int, int]]:
+    marked: list[bool] = [False] * len(heads)
+    cursor: int = 0
     marked[cursor] = True
     for i in range(len(heads)):
         bend = i
@@ -53,7 +55,7 @@ def traverse(heads):
         cursor = heads[cursor]
 
 
-def is_projective(heads):
+def is_projective(heads: list[int]) -> bool:
     seen = [False] * len(heads)
     for cursor, d in traverse(heads):
         if d == DN:
@@ -64,7 +66,7 @@ def is_projective(heads):
     return True
 
 
-def projectivize(heads):
+def projectivize(heads: list[int]) -> list[int]:
     pheads = [0] * len(heads)
     dangling = [[] for _ in heads]
     head_blk = [False] * len(heads)
@@ -85,7 +87,7 @@ def projectivize(heads):
     return pheads
 
 
-def projectivized_trees(fp):
+def projectivized_trees(fp: TextIO) -> Iterable[list[str]]:
     for tree in trees(fp):
         pheads = projectivize(heads(tree))
         for i, row in enumerate(tree):
@@ -93,13 +95,13 @@ def projectivized_trees(fp):
         yield tree
 
 
-def emit(tree):
+def emit(tree: list[str]) -> None:
     for row in tree:
         print("\t".join(row))
     print()
 
 
-def cmd_count_projective():
+def cmd_count_projective() -> None:
     import sys
 
     k = 0
@@ -110,14 +112,14 @@ def cmd_count_projective():
     print(f"{k / n:.2%}")
 
 
-def cmd_projectivize():
+def cmd_projectivize() -> None:
     import sys
 
     for ptree in projectivized_trees(sys.stdin):
         emit(ptree)
 
 
-def filename_projectivize(filename, target_filename):
+def filename_projectivize(filename: str, target_filename: str) -> None:
     with open(target_filename, "w") as file_out:
         with open(filename) as file_in:
             for ptree in projectivized_trees(file_in):

--- a/baseline/projectivize.py
+++ b/baseline/projectivize.py
@@ -7,13 +7,13 @@
 def trees(fp):
     buffer = []
     for line in fp:
-        line = line.rstrip()  # strip off the trailing newline
-        if not line.startswith("#"):
-            if len(line) == 0:
+        stripped_line = line.rstrip()  # strip off the trailing newline
+        if not stripped_line.startswith("#"):
+            if len(stripped_line) == 0:
                 yield buffer
                 buffer = []
             else:
-                columns = line.split("\t")
+                columns = stripped_line.split("\t")
                 if columns[0].isdigit():  # skip range tokens
                     buffer.append(columns)
 
@@ -107,7 +107,7 @@ def cmd_count_projective():
     for tree in trees(sys.stdin):
         k += is_projective(heads(tree))
         n += 1
-    print("{:.2%}".format(k / n))
+    print(f"{k / n:.2%}")
 
 
 def cmd_projectivize():
@@ -119,7 +119,7 @@ def cmd_projectivize():
 
 def filename_projectivize(filename, target_filename):
     with open(target_filename, "w") as file_out:
-        with open(filename, "r") as file_in:
+        with open(filename) as file_in:
             for ptree in projectivized_trees(file_in):
                 for row in ptree:
                     file_out.write("\t".join(row) + "\n")

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,4 @@
 lint.select = ["I", "F", "E", "B", "W", "D", "UP", "A", "C4", "ICN", "PL", "ARG", "RUF", "NPY"]
 # PLR2004 magic variable check, PLR0913 too many arguments should usually be on
 lint.ignore = ["D100","D101", "D102", "D103", "D105", "D107", "D211", "D213", "PLR2004", "PLR0913"] 
+lint.unfixable = ["F401"] # F401 is annoying if you are in the process of adding imports

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+lint.select = ["I", "F", "E", "B", "W", "D", "UP", "A", "C4", "ICN", "PL", "ARG", "RUF", "NPY"]
+# PLR2004 magic variable check, PLR0913 too many arguments should usually be on
+lint.ignore = ["D100","D101", "D102", "D103", "D105", "D107", "D211", "D213", "PLR2004", "PLR0913"] 


### PR DESCRIPTION
* Remove black as formatter and pylint as linter and add ruff as replacement for both. 
* Add unified VSCode settings for workspace with recommended extensions
* Format files with ruff
* Type code

